### PR TITLE
Change spacy requirement to <3.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = coreferee
-version = 1.1.0
+version = 1.1.1
 description = Coreference resolution for English, German and Polish, optimised for limited training data and easily extensible for further languages
 long_description = file: SHORTREADME.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ include_package_data = True
 packages = find:
 python_requires = >=3.9
 install_requires =
-  spacy>=3.1.0,<=3.2.0
+  spacy>=3.1.0,<3.2.0
   keras~=2.4.0
   tensorflow~=2.5.0
 [options.package_data]


### PR DESCRIPTION
spacy 3.2 models are not yet supported by coreferee so this prevents spacy 3.2.* from being downloaded